### PR TITLE
Load certificate authority data from a path specified in kube config …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roperator"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["pfried <philipsfried@gmail.com>"]
 edition = "2018"
 description = "Easily create Kubernetes Operators with Rust"

--- a/src/config/test-data/dummy-ca.crt
+++ b/src/config/test-data/dummy-ca.crt
@@ -1,0 +1,1 @@
+This is not a real certificate, and the file contents don't matter. This file just needs to exist, so that we can test the resolution of relative paths in a kubeconfig file.

--- a/src/config/test-data/kubeconfig-with-ca-file.yaml
+++ b/src/config/test-data/kubeconfig-with-ca-file.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Config
+current-context: ca-path-context
+clusters:
+- name: with-ca-path
+  cluster:
+    server: https://with-ca-path.test
+    certificate-authority: ./dummy-ca.crt
+contexts:
+- context:
+    cluster: with-ca-path
+    user: certificates
+  name: ca-path-context
+- context:
+    cluster: with-ca-path
+    user: certificates
+  name: ca-data-context
+preferences: {}
+users:
+- name: certificates
+  user:
+    client-certificate-data: ABC
+    client-key-data: '123'


### PR DESCRIPTION
…file, Fixes #7

One minor open issue remains, stemming from the fact that the `CAData::File` variant uses a String to represent a file path. This means that paths containing non-utf-8 characters won't work. I'll create another issue to change CAData to use a `PathBuf` instead, and get that into the 0.2 release.