### PR TITLE
support cert and key path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -188,6 +188,11 @@ pub enum Credentials {
         /// The private key that corresponds to the certificate above
         private_key_base64: String,
     },
+
+    PemPath {
+        certificate_path: String,
+        private_key_path: String,
+    },
 }
 
 /// Configuration for how to connect to the Kubernetes API server and authenticate. This configuration


### PR DESCRIPTION
I had a hard time to use roperator with minikube which doesn't safe the certificates inline, but instead in seperate files. I added this to roperator.