### PR TITLE
Set the AWS token to have a 'Bearer' prefix

### DIFF
--- a/src/config/kubeconfig.rs
+++ b/src/config/kubeconfig.rs
@@ -158,7 +158,7 @@ fn get_exec_token(exec: &Exec) -> Result<String, KubeConfigError> {
         exec.command,
         credential.status.expiration_timestamp
     );
-    Ok(credential.status.token)
+    Ok(format!("Bearer {}", credential.status.token))
 }
 
 /// used only for deserializing the output of the `exec` command for retrieving credentials


### PR DESCRIPTION
I was unable to get the echo-server to work on our EKS cluster, and found that the Authorization header was not prefixing the token with "Bearer".