### PR TITLE
Request has child

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           export KUBECONFIG="$(kind get kubeconfig-path)"
           kubectl cluster-info
           kubectl apply -f tests/resources/
-          cargo test --features testkit
+          cargo test --features 'testkit test'
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ env_logger = "0.7.1"
 [features]
 default = []
 testkit = []
+# The reason we do this is because doctests don't get cfg(test)
+# See: https://github.com/rust-lang/cargo/issues/4669
+test = []
 
 [[test]]
 name = "integration_tests"

--- a/docs/guide/upgrade_guide.md
+++ b/docs/guide/upgrade_guide.md
@@ -24,11 +24,13 @@ There were a number of breaking changes in the 0.2.0 release. Most of them were 
 
 `TypedView`:
 
+- Changed the signatures of `get` and `exists` functions to accept `impl Into<ObjectIdRef<'a>>` instead of separate `namespace` and `name` arguments. Now you can pass `&ObjectId`, `ObjectIdRef`, or `(&str, &str)`
 - Removed the `iter_raw` function. Use `as_raw().iter()` instead
 - Changed the struct declaration to specify separate lifetimes for the inner `SyncRequest` and the `K8sTypeRef`. This should not impact most usages, but may if you're written out the full type on a variable
 
 `RawView`:
 
+- Changed the signatures of `get` and `exists` functions to accept `impl Into<ObjectIdRef<'a>>` instead of separate `namespace` and `name` arguments. Now you can pass `&ObjectId`, `ObjectIdRef`, or `(&str, &str)`
 - Changed the struct declaration to specify separate lifetimes for the inner `SyncRequest` and the `K8sTypeRef`. This should not impact most usages, but may if you're written out the full type on a variable
 
 There were also a number of breaking changes in the `roperator::resource` module. These were mostly to simplify dealing with Kubernetes resources that are represented as plain JSON. Every resource has a type (represented by an `apiVersion` and `kind`) and an `id` (represented by `metadata.namespace` and `metadata.name`). The representations of these have been simplified, and various things were added/changed to allow functions to accept a variety of representations of these.

--- a/docs/guide/upgrade_guide.md
+++ b/docs/guide/upgrade_guide.md
@@ -34,4 +34,6 @@ There were a number of breaking changes in the 0.2.0 release. Most of them were 
 There were also a number of breaking changes in the `roperator::resource` module. These were mostly to simplify dealing with Kubernetes resources that are represented as plain JSON. Every resource has a type (represented by an `apiVersion` and `kind`) and an `id` (represented by `metadata.namespace` and `metadata.name`). The representations of these have been simplified, and various things were added/changed to allow functions to accept a variety of representations of these.
 
 - `roperator::resource::object_id` function was removed. Use the `get_object_id` function from the `ResourceJson` trait instead.
+- `roperator::resource::type_ref` function was removed. Use the `get_type_ref` function from the `ResourceJson` trait instead.
+- `roperator::resource::str_value` function was removed. Use `Value::pointer(&str).and_then(Value::as_str)` instead.
 

--- a/docs/guide/upgrade_guide.md
+++ b/docs/guide/upgrade_guide.md
@@ -31,3 +31,7 @@ There were a number of breaking changes in the 0.2.0 release. Most of them were 
 
 - Changed the struct declaration to specify separate lifetimes for the inner `SyncRequest` and the `K8sTypeRef`. This should not impact most usages, but may if you're written out the full type on a variable
 
+There were also a number of breaking changes in the `roperator::resource` module. These were mostly to simplify dealing with Kubernetes resources that are represented as plain JSON. Every resource has a type (represented by an `apiVersion` and `kind`) and an `id` (represented by `metadata.namespace` and `metadata.name`). The representations of these have been simplified, and various things were added/changed to allow functions to accept a variety of representations of these.
+
+- `roperator::resource::object_id` function was removed. Use the `get_object_id` function from the `ResourceJson` trait instead.
+

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,6 +5,11 @@
 //! snapshot of the state of a given parent resource, along with any children that currently exist for it.
 //! This request struct has lots of functions on it for accessing and deserializing child resources.
 
+// only expose the reqeust mod during tests.
+#[cfg(feature = "test")]
+pub mod request;
+
+#[cfg(not(feature = "test"))]
 mod request;
 
 use crate::error::Error;

--- a/src/handler/request.rs
+++ b/src/handler/request.rs
@@ -4,8 +4,8 @@
 use crate::k8s_types::K8sType;
 use crate::resource::{K8sResource, K8sTypeRef, ObjectIdRef, ResourceJson};
 
-use serde_json::Value;
 use serde::de::DeserializeOwned;
+use serde_json::Value;
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
@@ -313,10 +313,7 @@ impl<'a> RequestChildren<'a> {
     /// - `apiVersion`
     /// - `kind`
     /// - `metadata.name`
-    pub fn get_child_with_id<'b>(
-        &self,
-        resource: &'b Value,
-    ) -> Option<&'a K8sResource> {
+    pub fn get_child_with_id<'b>(&self, resource: &'b Value) -> Option<&'a K8sResource> {
         let type_id = resource
             .get_type_ref()
             .and_then(|v| resource.get_id_ref().map(move |id| (v, id)));

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,5 +1,5 @@
-pub(crate) mod object_id;
 mod json_ext;
+pub(crate) mod object_id;
 
 use crate::k8s_types::K8sType;
 
@@ -290,4 +290,3 @@ impl<'a> From<(&'a str, &'a str)> for K8sTypeRef<'a> {
         K8sTypeRef(api_version, kind)
     }
 }
-

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -238,15 +238,6 @@ impl Into<Value> for K8sResource {
     }
 }
 
-pub fn type_ref(json: &Value) -> Option<K8sTypeRef<'_>> {
-    str_value(json, "/apiVersion")
-        .and_then(|api_version| str_value(json, "/kind").map(|kind| K8sTypeRef(api_version, kind)))
-}
-
-pub fn str_value<'a, 'b>(json: &'a Value, pointer: &'b str) -> Option<&'a str> {
-    json.pointer(pointer).and_then(Value::as_str)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub struct K8sTypeRef<'a>(pub &'a str, pub &'a str);
 impl<'a> K8sTypeRef<'a> {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -91,13 +91,17 @@ impl K8sResource {
         self.0
     }
 
+    pub fn is_id(&self, id: &ObjectIdRef) -> bool {
+        self.get_object_id() == *id
+    }
+
     /// Returns `true` if this resource is of the given type (matches the apiVersion and kind)
     pub fn is_type(&self, k8s_type: &K8sType) -> bool {
         self.api_version() == k8s_type.api_version && self.kind() == k8s_type.kind
     }
 
     /// returns the `metadata.resourceVersion`, which is guaranteed to exist
-    pub fn get_resource_version(&self) -> &str {
+    pub fn resource_version(&self) -> &str {
         self.str_value("/metadata/resourceVersion").unwrap()
     }
 

--- a/src/resource/json_ext.rs
+++ b/src/resource/json_ext.rs
@@ -1,5 +1,5 @@
-use serde_json::{Value};
 use crate::resource::{K8sTypeRef, ObjectIdRef};
+use serde_json::Value;
 
 pub static API_VERSION_POINTER: &str = "/apiVersion";
 pub static KIND_POINTER: &str = "/kind";

--- a/src/resource/json_ext.rs
+++ b/src/resource/json_ext.rs
@@ -1,0 +1,48 @@
+use serde_json::{Value};
+use crate::resource::{K8sTypeRef, ObjectIdRef};
+
+pub static API_VERSION_POINTER: &str = "/apiVersion";
+pub static KIND_POINTER: &str = "/kind";
+pub static NAMESPACE_POINTER: &str = "/metadata/namespace";
+pub static NAME_POINTER: &str = "/metadata/name";
+
+pub trait ResourceJson: std::fmt::Display {
+    fn get_api_version(&self) -> Option<&str>;
+    fn get_kind(&self) -> Option<&str>;
+    fn get_namespace(&self) -> Option<&str>;
+    fn get_name(&self) -> Option<&str>;
+
+    fn get_type_ref(&self) -> Option<K8sTypeRef> {
+        let api_version = self.get_api_version()?;
+        let kind = self.get_kind()?;
+        Some(K8sTypeRef::new(api_version, kind))
+    }
+
+    fn get_id_ref(&self) -> Option<ObjectIdRef> {
+        let namespace = self.get_namespace().unwrap_or("");
+        let name = self.get_name()?;
+        Some(ObjectIdRef::new(namespace, name))
+    }
+}
+
+fn str_value<'a, 'b>(value: &'a Value, pointer: &'b str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+impl ResourceJson for Value {
+    fn get_api_version(&self) -> Option<&str> {
+        str_value(self, API_VERSION_POINTER)
+    }
+
+    fn get_kind(&self) -> Option<&str> {
+        str_value(self, KIND_POINTER)
+    }
+
+    fn get_namespace(&self) -> Option<&str> {
+        str_value(self, NAMESPACE_POINTER)
+    }
+
+    fn get_name(&self) -> Option<&str> {
+        str_value(self, NAME_POINTER)
+    }
+}

--- a/src/resource/object_id.rs
+++ b/src/resource/object_id.rs
@@ -32,10 +32,7 @@ pub struct ObjectId {
 impl ObjectId {
     /// create a new `ObjectId` from owned Strings
     pub fn new(namespace: String, name: String) -> ObjectId {
-        ObjectId {
-            namespace,
-            name,
-        }
+        ObjectId { namespace, name }
     }
 
     /// return an `ObjectIdRef` that borrows its fields from this id
@@ -58,7 +55,6 @@ impl ObjectId {
     }
 }
 
-
 impl Display for ObjectId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.as_id_ref().fmt(f)
@@ -75,10 +71,7 @@ pub struct ObjectIdRef<'a> {
 impl<'a> ObjectIdRef<'a> {
     /// Returns a new id with the given namespace and name fields
     pub fn new(namespace: &'a str, name: &'a str) -> ObjectIdRef<'a> {
-        ObjectIdRef {
-            namespace,
-            name,
-        }
+        ObjectIdRef { namespace, name }
     }
 
     /// Create an owned `ObjectId` by copying the borrowed fields to
@@ -114,15 +107,13 @@ impl<'a> Display for ObjectIdRef<'a> {
 
 impl<'a> PartialEq<ObjectIdRef<'a>> for ObjectId {
     fn eq(&self, other: &ObjectIdRef<'a>) -> bool {
-        self.namespace == other.namespace &&
-            self.name == other.name
+        self.namespace == other.namespace && self.name == other.name
     }
 }
 
 impl<'a> PartialEq<ObjectId> for ObjectIdRef<'a> {
     fn eq(&self, other: &ObjectId) -> bool {
-        self.namespace == other.namespace &&
-            self.name == other.name
+        self.namespace == other.namespace && self.name == other.name
     }
 }
 

--- a/src/resource/object_id.rs
+++ b/src/resource/object_id.rs
@@ -1,0 +1,170 @@
+//! All Kubernetes resources have an id, which is the combination of the
+//! `namespace` and `name` fields from the `metadata`. Although the `metadata`
+//! also includes a `uid` field, we typically only use that in order to
+//! differentiate different resources in the case where one is deleted and
+//! another is subsequently created with the same namespace and name.
+//!
+//! Both of the structs defined here are just holders of a namespace and name.
+//! `ObjectId` represents an _owned_ object id, which `ObjectIdRef` represents
+//! one that _borrows_ its fields (typically from a json `Value`).
+//!
+//! Many functions will accept `impl Into<ObjectIdRef<'_>>`, which allows passing
+//! either an owned or borrowed version, as well as `(&str, &str)`.
+//!
+//! ### Note on optional namespaces
+//!
+//! Namespaces are optional on many Kuberentes resources. Some resources are simply
+//! non-namspaced. For others, a missing namespace just communicates a desire to use
+//! the _default_ namespace of the current user. In this case, an empty namespace is
+//! treated the same as one where it is undefined. Both representations of object ids
+//! in roperator represent missing namespaces as empty strings. The `namespace()`
+//! function will return an `Option<&str>` to help with cases where you need to determine
+//! if a namespace is present or not.
+use std::fmt::{self, Display};
+
+/// An owned Object Id
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ObjectId {
+    pub namespace: String,
+    pub name: String,
+}
+
+impl ObjectId {
+    /// create a new `ObjectId` from owned Strings
+    pub fn new(namespace: String, name: String) -> ObjectId {
+        ObjectId {
+            namespace,
+            name,
+        }
+    }
+
+    /// return an `ObjectIdRef` that borrows its fields from this id
+    pub fn as_id_ref(&self) -> ObjectIdRef {
+        ObjectIdRef {
+            namespace: &self.namespace,
+            name: &self.name,
+        }
+    }
+
+    /// Returns an option containing a non-empty namespace. Will return None
+    /// if the namespace is an empty string.
+    pub fn namespace(&self) -> Option<&str> {
+        self.as_id_ref().namespace()
+    }
+
+    /// returns the name
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+
+impl Display for ObjectId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.as_id_ref().fmt(f)
+    }
+}
+
+/// An id that borrows its fields
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ObjectIdRef<'a> {
+    pub namespace: &'a str,
+    pub name: &'a str,
+}
+
+impl<'a> ObjectIdRef<'a> {
+    /// Returns a new id with the given namespace and name fields
+    pub fn new(namespace: &'a str, name: &'a str) -> ObjectIdRef<'a> {
+        ObjectIdRef {
+            namespace,
+            name,
+        }
+    }
+
+    /// Create an owned `ObjectId` by copying the borrowed fields to
+    /// newly allocated ones
+    pub fn to_owned(&self) -> ObjectId {
+        ObjectId {
+            namespace: self.namespace.to_owned(),
+            name: self.name.to_owned(),
+        }
+    }
+
+    /// Returns an option containing a non-empty namespace. Will return None
+    /// if the namespace is an empty string.
+    pub fn namespace(&self) -> Option<&'a str> {
+        if self.namespace.is_empty() {
+            None
+        } else {
+            Some(self.namespace)
+        }
+    }
+
+    /// returns the name field
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+}
+
+impl<'a> Display for ObjectIdRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}/{}", self.namespace, self.name)
+    }
+}
+
+impl<'a> PartialEq<ObjectIdRef<'a>> for ObjectId {
+    fn eq(&self, other: &ObjectIdRef<'a>) -> bool {
+        self.namespace == other.namespace &&
+            self.name == other.name
+    }
+}
+
+impl<'a> PartialEq<ObjectId> for ObjectIdRef<'a> {
+    fn eq(&self, other: &ObjectId) -> bool {
+        self.namespace == other.namespace &&
+            self.name == other.name
+    }
+}
+
+impl<'a> From<&'a ObjectId> for ObjectIdRef<'a> {
+    fn from(id: &'a ObjectId) -> ObjectIdRef<'a> {
+        id.as_id_ref()
+    }
+}
+
+impl<'a> From<(&'a str, &'a str)> for ObjectIdRef<'a> {
+    fn from((namespace, name): (&'a str, &'a str)) -> ObjectIdRef<'a> {
+        ObjectIdRef { namespace, name }
+    }
+}
+
+impl<'a, 'b> From<&'b ObjectIdRef<'a>> for ObjectIdRef<'a> {
+    fn from(other: &'b ObjectIdRef<'a>) -> ObjectIdRef<'a> {
+        other.clone()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    #[test]
+    fn object_id_has_same_hash_as_ref() {
+        let id = ObjectId {
+            namespace: "foo".to_string(),
+            name: "bar".to_string(),
+        };
+        let id_ref = id.as_id_ref();
+
+        assert_eq!(hash(&id), hash(&id_ref));
+        assert_eq!(&id, &id_ref);
+    }
+
+    fn hash<T: Hash>(obj: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        obj.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/src/runner/client/request.rs
+++ b/src/runner/client/request.rs
@@ -49,7 +49,7 @@ impl Patch {
             "metadata": {
                 "namespace": resource.get_object_id().namespace(),
                 "name": resource.get_object_id().name(),
-                "resourceVersion": resource.get_resource_version(),
+                "resourceVersion": resource.resource_version(),
                 "finalizers": finalizers,
             }
         });
@@ -71,7 +71,7 @@ impl Patch {
             "metadata": {
                 "namespace": resource.get_object_id().namespace(),
                 "name": resource.get_object_id().name(),
-                "resourceVersion": resource.get_resource_version(),
+                "resourceVersion": resource.resource_version(),
                 "finalizers": finalizers,
             }
         });

--- a/src/runner/informer.rs
+++ b/src/runner/informer.rs
@@ -567,7 +567,7 @@ impl<I: ReverseIndex> ResourceMonitorBackend<I> {
             }
         };
         let resource = K8sResource::from_value(object)?;
-        let resource_version = resource.get_resource_version().to_owned();
+        let resource_version = resource.resource_version().to_owned();
 
         let resource_id = resource.get_object_id().to_owned();
         let resource_type = self.k8s_type;

--- a/src/runner/informer.rs
+++ b/src/runner/informer.rs
@@ -1,13 +1,13 @@
 use crate::error::Error;
 use crate::k8s_types::K8sType;
-use crate::resource::{InvalidResourceError, K8sResource, ObjectId, };
+use crate::resource::{InvalidResourceError, K8sResource, ObjectId};
 
 #[cfg(feature = "testkit")]
 use crate::resource::ObjectIdRef;
 
 use crate::runner::client::{ApiError, Client, Error as ClientError, ObjectList, WatchEvent};
 use crate::runner::metrics::WatcherMetrics;
-use crate::runner::resource_map::{ResourceMap, IdSet};
+use crate::runner::resource_map::{IdSet, ResourceMap};
 
 use serde_json::Value;
 use tokio::executor::Executor;
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::sync::Arc;
-
 
 #[derive(Debug)]
 pub struct LabelToIdIndex {

--- a/src/runner/metrics.rs
+++ b/src/runner/metrics.rs
@@ -27,7 +27,8 @@ impl Debug for Metrics {
 }
 
 fn id_labels<'a, 'b>(id: &'a ObjectIdRef<'b>) -> [&'a str; 2] {
-    [id.as_parts().0, id.as_parts().1]
+    let ObjectIdRef {namespace, name } = *id;
+    [namespace, name]
 }
 
 // 5, 10, 20, 40, 80, 160, 320, 640, 1280, 2560, 5120

--- a/src/runner/metrics.rs
+++ b/src/runner/metrics.rs
@@ -27,7 +27,7 @@ impl Debug for Metrics {
 }
 
 fn id_labels<'a, 'b>(id: &'a ObjectIdRef<'b>) -> [&'a str; 2] {
-    let ObjectIdRef {namespace, name } = *id;
+    let ObjectIdRef { namespace, name } = *id;
     [namespace, name]
 }
 

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,8 +1,8 @@
 mod client;
 mod informer;
 mod metrics;
-pub(crate) mod resource_map;
 pub(crate) mod reconcile;
+pub(crate) mod resource_map;
 mod server;
 
 #[cfg(feature = "testkit")]
@@ -508,7 +508,9 @@ impl OperatorState {
             }
             EventType::Deleted if resource_type == self.runtime_config.parent_type => {
                 log::debug!("Parent resource '{}' has been deleted", resource_id);
-                self.runtime_config.metrics.parent_deleted(&resource_id.as_id_ref());
+                self.runtime_config
+                    .metrics
+                    .parent_deleted(&resource_id.as_id_ref());
             }
             _ => {
                 if to_sync.insert(uid) {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod informer;
 mod metrics;
+pub(crate) mod resource_map;
 pub(crate) mod reconcile;
 mod server;
 
@@ -367,7 +368,7 @@ impl OperatorState {
             }
         };
 
-        let parent_id = parent.get_object_id().into_owned();
+        let parent_id = parent.get_object_id().to_owned();
         log::info!(
             "Starting sync request for parent: '{}' with uid: '{}'",
             parent_id,
@@ -507,7 +508,7 @@ impl OperatorState {
             }
             EventType::Deleted if resource_type == self.runtime_config.parent_type => {
                 log::debug!("Parent resource '{}' has been deleted", resource_id);
-                self.runtime_config.metrics.parent_deleted(&resource_id);
+                self.runtime_config.metrics.parent_deleted(&resource_id.as_id_ref());
             }
             _ => {
                 if to_sync.insert(uid) {

--- a/src/runner/reconcile/finalize.rs
+++ b/src/runner/reconcile/finalize.rs
@@ -18,7 +18,8 @@ pub(crate) async fn handle_finalize(handler: SyncHandler) {
         parent_index_key,
     } = handler;
 
-    let parent_id = request.parent.get_object_id().into_owned();
+    let parent_id = request.parent.get_object_id().to_owned();
+    let parent_id_ref = parent_id.as_id_ref();
     let parent_type = runtime_config.parent_type;
 
     let result = get_finalize_result(request, handler, client, &*runtime_config).await;
@@ -31,7 +32,7 @@ pub(crate) async fn handle_finalize(handler: SyncHandler) {
             retry
         }
         Err(err) => {
-            runtime_config.metrics.parent_sync_error(&parent_id);
+            runtime_config.metrics.parent_sync_error(&parent_id_ref);
             log::error!("Failed to finalize parent: {}, err: {}", parent_id, err);
             // here again, we should change this to use an incremental backoff instead of these fixed delays
             tokio::timer::delay_for(Duration::from_secs(5)).await;

--- a/src/runner/reconcile/mod.rs
+++ b/src/runner/reconcile/mod.rs
@@ -88,7 +88,7 @@ pub(crate) async fn update_status_if_different(
 ) -> Result<(), UpdateError> {
     let parent_id = existing_parent.get_object_id();
     let old_status = existing_parent.status();
-    let parent_resource_version = existing_parent.get_resource_version();
+    let parent_resource_version = existing_parent.resource_version();
     let current_gen = existing_parent.generation();
 
     if let Some(s) = new_status.as_object_mut() {

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -1,8 +1,6 @@
 use crate::config::UpdateStrategy;
 use crate::handler::{Handler, SyncRequest, SyncResponse};
-use crate::resource::{
-    InvalidResourceError, JsonObject, K8sResource, ObjectIdRef, ResourceJson,
-};
+use crate::resource::{InvalidResourceError, JsonObject, K8sResource, ObjectIdRef, ResourceJson};
 use crate::runner::client::{self, Client};
 use crate::runner::informer::{EventType, ResourceMessage};
 use crate::runner::reconcile::compare::compare_values;

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -209,7 +209,7 @@ async fn update_children(
         let existing_child = req
             .children()
             .of_type(child_config.child_type)
-            .get(child_id.namespace().unwrap_or(""), child_id.name());
+            .get(&child_id);
         let update_required =
             is_child_update_required(&parent_id, child_config, existing_child, &child_id.as_id_ref(), &child)?;
         add_parent_references(runtime_config, parent_id.name(), parent_uid, &mut child)?;
@@ -346,7 +346,7 @@ fn determine_update_type(
         // since deletion can sometimes take quite a while due to finalizers needing to run.
         Some(UpdateType::Delete)
     } else {
-        let resource_version = existing_child.get_resource_version();
+        let resource_version = existing_child.resource_version();
         Some(UpdateType::Replace(resource_version.to_owned()))
     }
 }

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -1,7 +1,7 @@
 use crate::config::UpdateStrategy;
 use crate::handler::{Handler, SyncRequest, SyncResponse};
 use crate::resource::{
-    type_ref, InvalidResourceError, JsonObject, K8sResource, ObjectIdRef, ResourceJson,
+    InvalidResourceError, JsonObject, K8sResource, ObjectIdRef, ResourceJson,
 };
 use crate::runner::client::{self, Client};
 use crate::runner::informer::{EventType, ResourceMessage};
@@ -193,7 +193,7 @@ async fn update_children(
         }
 
         let child_config: &ChildRuntimeConfig = {
-            let child_type_ref = type_ref(&child).ok_or_else(|| {
+            let child_type_ref = child.get_type_ref().ok_or_else(|| {
                 InvalidResourceError::new("missing either apiVersion or kind", child.clone())
             })?;
 

--- a/src/runner/resource_map.rs
+++ b/src/runner/resource_map.rs
@@ -17,9 +17,10 @@ impl<T> IdMap<T> {
     pub fn contains<'a>(&self, id: impl Into<ObjectIdRef<'a>>) -> bool {
         let id = id.into();
 
-        self.0.get(id.namespace).map(|by_name| {
-            by_name.contains_key(id.name)
-        }).unwrap_or(false)
+        self.0
+            .get(id.namespace)
+            .map(|by_name| by_name.contains_key(id.name))
+            .unwrap_or(false)
     }
 
     pub fn remove<'a>(&mut self, id: impl Into<ObjectIdRef<'a>>) {
@@ -41,7 +42,6 @@ impl<T> IdMap<T> {
 }
 
 impl IdMap<K8sResource> {
-
     pub fn insert(&mut self, resource: K8sResource) -> Option<K8sResource> {
         let ObjectId { namespace, name } = resource.get_object_id().to_owned();
         let by_name = self.0.entry(namespace).or_default();
@@ -71,14 +71,9 @@ impl IdMap<()> {
 
     pub fn iter(&self) -> impl Iterator<Item = ObjectIdRef> {
         self.0.iter().flat_map(|(namespace, by_name)| {
-            by_name.keys().map(move |name| {
-                ObjectIdRef {
-                    namespace,
-                    name,
-                }
-            })
+            by_name
+                .keys()
+                .map(move |name| ObjectIdRef { namespace, name })
         })
     }
 }
-
-

--- a/src/runner/resource_map.rs
+++ b/src/runner/resource_map.rs
@@ -1,0 +1,84 @@
+use crate::resource::object_id::{ObjectId, ObjectIdRef};
+use crate::resource::K8sResource;
+
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct IdMap<T>(HashMap<String, HashMap<String, T>>);
+
+pub type ResourceMap = IdMap<K8sResource>;
+pub type IdSet = IdMap<()>;
+
+impl<T> IdMap<T> {
+    pub fn new() -> IdMap<T> {
+        IdMap(HashMap::new())
+    }
+
+    pub fn contains<'a>(&self, id: impl Into<ObjectIdRef<'a>>) -> bool {
+        let id = id.into();
+
+        self.0.get(id.namespace).map(|by_name| {
+            by_name.contains_key(id.name)
+        }).unwrap_or(false)
+    }
+
+    pub fn remove<'a>(&mut self, id: impl Into<ObjectIdRef<'a>>) {
+        let id = id.into();
+        if let Some(by_name) = self.0.get_mut(id.namespace) {
+            by_name.remove(id.name);
+        }
+    }
+
+    pub fn clear(&mut self) {
+        for by_name in self.0.values_mut() {
+            by_name.clear();
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.values().map(HashMap::len).sum()
+    }
+}
+
+impl IdMap<K8sResource> {
+
+    pub fn insert(&mut self, resource: K8sResource) -> Option<K8sResource> {
+        let ObjectId { namespace, name } = resource.get_object_id().to_owned();
+        let by_name = self.0.entry(namespace).or_default();
+        by_name.insert(name, resource)
+    }
+
+    pub fn get<'a, 'b>(&'a self, id: impl Into<ObjectIdRef<'b>>) -> Option<&'a K8sResource> {
+        let id = id.into();
+        if let Some(by_name) = self.0.get(id.namespace) {
+            by_name.get(id.name)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_copy<'a>(&self, id: impl Into<ObjectIdRef<'a>>) -> Option<K8sResource> {
+        self.get(id).cloned()
+    }
+}
+
+impl IdMap<()> {
+    pub fn insert(&mut self, id: ObjectId) -> bool {
+        let ObjectId { namespace, name } = id;
+        let by_name = self.0.entry(namespace).or_default();
+        by_name.insert(name, ()).is_none()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ObjectIdRef> {
+        self.0.iter().flat_map(|(namespace, by_name)| {
+            by_name.keys().map(move |name| {
+                ObjectIdRef {
+                    namespace,
+                    name,
+                }
+            })
+        })
+    }
+}
+
+

--- a/src/runner/testkit/mod.rs
+++ b/src/runner/testkit/mod.rs
@@ -654,7 +654,7 @@ impl Handler for InstrumentedHandler {
             ref records,
         } = self;
 
-        let parent_id = req.parent.get_object_id().into_owned();
+        let parent_id = req.parent.get_object_id().to_owned();
         let mut records_lock = records.write().unwrap();
         let record = records_lock
             .entry(parent_id)
@@ -672,7 +672,7 @@ impl Handler for InstrumentedHandler {
             ref records,
         } = self;
 
-        let parent_id = req.parent.get_object_id().into_owned();
+        let parent_id = req.parent.get_object_id().to_owned();
         let mut records_lock = records.write().unwrap();
         let record = records_lock
             .entry(parent_id)


### PR DESCRIPTION
This implements some of the suggestions from #12 . The reality of this ended up being a bit more tricky than expected. Basically, just because a resource exists in the `SyncRequest::children()` doesn't necessarily imply anything about its state. For example, a Pod resource could exist, even though the Pod _status_ indicates that it's no longer running. So a general function that's like `fn does_resource_exist(example_resource: &Value) -> bool` isn't actually a good fit in all cases, since the word "exist" could be interpreted in multiple ways, and a `bool` isn't actually a rich enough type to represent all the possible states.

So the solution I settled on for this was to simply have a function that returns a matching child resource if one exists. That way, users can inspect the state of it to decide how they should proceed.

In addition to the above, I made some other quality of life improvements on `RequestChildren` and `Raw/TypedView`, and refactored the `ObjectId` and `ObjectIdRef` types. All the `Raw/TypedView` functions now accept `impl Into<ObjectIdRef<'_>>` instead of separate `namespace` and `name` arguments. This allows a lot more flexibility in how you can query about resources in `RequestChildren`, as it allows all functions to accept `&ObjectId` and `(&str, &str)` in addition to `ObjectIdRef`.