### PR TITLE
Add ability to specify a resync for some point in the future

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.39.0
           override: true
       - uses: engineerd/setup-kind@v0.1.0
       - uses: actions-rs/cargo@v1
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.39.0
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.39.0
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/examples/echo-server/main.rs
+++ b/examples/echo-server/main.rs
@@ -101,7 +101,11 @@ fn handle_sync(request: &SyncRequest) -> Result<SyncResponse, Error> {
         "message": get_current_status_message(request),
     });
     let children = get_desired_children(request)?;
-    Ok(SyncResponse { status, children, resync: None })
+    Ok(SyncResponse {
+        status,
+        children,
+        resync: None,
+    })
 }
 
 /// Returns the json value that should be set on the parent EchoServer

--- a/examples/echo-server/main.rs
+++ b/examples/echo-server/main.rs
@@ -101,7 +101,7 @@ fn handle_sync(request: &SyncRequest) -> Result<SyncResponse, Error> {
         "message": get_current_status_message(request),
     });
     let children = get_desired_children(request)?;
-    Ok(SyncResponse { status, children })
+    Ok(SyncResponse { status, children, resync: None })
 }
 
 /// Returns the json value that should be set on the parent EchoServer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //!     Ok(SyncResponse {
 //!         status,
 //!         children: vec![pod],
+//!         resync: None,
 //!     })
 //! }
 //! ```

--- a/src/runner/informer.rs
+++ b/src/runner/informer.rs
@@ -16,8 +16,8 @@ use tokio::sync::{Mutex, MutexGuard};
 
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
-use std::hash::Hash;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[derive(Debug)]
 pub struct LabelToIdIndex {
@@ -193,35 +193,23 @@ impl CacheAndIndex<LabelToIdIndex> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub enum EventType {
     Created,
     Updated,
     Finalizing,
     Deleted,
-    UpdateOperationComplete { retry: bool },
+    UpdateOperationComplete { resync: Option<Duration> },
+    TriggerResync { resync_round: u32 },
+
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Debug)]
 pub struct ResourceMessage {
     pub event_type: EventType,
     pub resource_type: &'static K8sType,
     pub resource_id: ObjectId,
     pub index_key: Option<String>,
-}
-
-impl Debug for ResourceMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "{}({:?}, {}, {}, {:?})",
-            std::any::type_name::<ResourceMessage>(),
-            self.event_type,
-            self.resource_type,
-            self.resource_id,
-            self.index_key
-        )
-    }
 }
 
 pub struct ResourceState<'a, I: ReverseIndex>(MutexGuard<'a, CacheAndIndex<I>>);

--- a/src/runner/informer.rs
+++ b/src/runner/informer.rs
@@ -201,7 +201,6 @@ pub enum EventType {
     Deleted,
     UpdateOperationComplete { resync: Option<Duration> },
     TriggerResync { resync_round: u32 },
-
 }
 
 #[derive(Debug)]

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -14,7 +14,7 @@ use serde_json::{json, Value};
 use tokio::timer::delay_for;
 
 use std::sync::Arc;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 pub(crate) async fn handle_sync(handler: SyncHandler) {
     let SyncHandler {
@@ -103,7 +103,9 @@ async fn update_all(
     runtime_config: &RuntimeConfig,
 ) -> Result<(), UpdateError> {
     let start_time = Instant::now();
-    let SyncResponse { status, children, .. } = handler_response;
+    let SyncResponse {
+        status, children, ..
+    } = handler_response;
     let parent_id = request.parent.get_object_id().to_owned();
     update_status_if_different(&request.parent, &client, runtime_config, status).await?;
     log::debug!(

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -90,7 +90,7 @@ async fn private_handle_sync(
             .await
         };
         let response = sync_result.map_err(|e| UpdateError::HandlerError(e))?;
-        let resync = response.resync.clone();
+        let resync = response.resync;
         update_all(request, response, client, runtime_config).await?;
         Ok(resync)
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,9 +5,9 @@ use roperator::runner::testkit::{HandlerErrors, TestKit};
 use roperator::serde_json::{json, Value};
 
 use std::fmt::{self, Display};
-use std::time::Duration;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 fn make_client_config(operator_name: &str) -> ClientConfig {
     if let Ok(conf) = ClientConfig::from_service_account(operator_name) {
@@ -207,10 +207,7 @@ fn operator_retries_finalize_when_response_retry_is_some() {
             } else {
                 Some(Duration::from_millis(5))
             };
-            Ok(FinalizeResponse {
-                status,
-                retry,
-            })
+            Ok(FinalizeResponse { status, retry })
         }
     }
 
@@ -395,10 +392,12 @@ fn handler_is_invoked_after_waiting_when_resync_is_some() {
         .expect("failed to create parent resource");
 
     let start = std::time::Instant::now();
-    while counter.load(Ordering::SeqCst) < EXPECTED_SYNCS &&
-            start.elapsed() < Duration::from_secs(5)
+    while counter.load(Ordering::SeqCst) < EXPECTED_SYNCS
+        && start.elapsed() < Duration::from_secs(5)
     {
-        testkit.reconcile(Duration::from_secs(1)).expect("failed to reconcile");
+        testkit
+            .reconcile(Duration::from_secs(1))
+            .expect("failed to reconcile");
     }
 
     let actual_syncs = counter.load(Ordering::SeqCst);


### PR DESCRIPTION
This PR doesn't add all of the error handling functionality we want, but rather just lays some of the groundwork. This implements a breaking change to the `SyncResponse` to add a new `resync` field. This field holds an `Option<std::time::Duration>`. If it's `Some`, then roperator will schedule a resync of the parent after the given time has elapsed. If `None` then the parent will only be synced again upon triggering any of the usual conditions. 

The idea is that we can then support a variety of error handling and backoff strategies within handlers themselves, and can add provide an implementation that implements reasonable defaults.

It's also worth pointing out that this is all only for handling errors that originate from within the Handler impl itself. None of this applies to errors that originate from roperator itself of the k8s api server, since there's little that the Handler could do about those anyway. We might want to also add some sort of custom error handling for that type of thing, but it would be much more coarse grained, and would probably need to be provided in the `OperatorConfig` instead of the `SyncResponse`

Finally, as implemented, this also supports scheduling re-syncs for happy-path scenarios, in addition to error-handling. These scenarios aren't super common, but there are definitely use cases where it's important. For example, if your operator syncs some state from a k8s resource to an external system, then it might be useful to check periodically in case the external resource gets out of sync.