### PR TITLE
Add exponential backoff with error handling updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ dirs = "2.0"
 base64 = "0.11"
 urlencoding = "1.0"
 prometheus = "0.7"
+backoff = "0.1.6"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.6.0", default-features = false, features = ["v1_15"] }

--- a/examples/echo-server/main.rs
+++ b/examples/echo-server/main.rs
@@ -113,6 +113,7 @@ fn handle_sync(request: &SyncRequest) -> Result<SyncResponse, Error> {
 /// This function gets called by the operator whenever the sync handler responds with an error.
 /// It needs to respond with the appropriate status for the given request and error and the minimum length of
 /// time to wait before calling `handle_sync` again.
+//// This example will never actually get called.
 fn handle_error(request: &SyncRequest, err: Error) -> (Value, Option<Duration>) {
     log::error!("Failed to process request: {:?}\nCause: {:?}", request, err);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use crate::k8s_types::K8sType;
 
 use std::collections::HashMap;
 use std::io;
-use std::{time::Duration, path::Path};
+use std::{path::Path, time::Duration};
 
 /// Default label that's added to all child resources, so that roperator can track the ownership of resources.
 /// The value is the `metadata.uid` of the parent.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -156,14 +156,17 @@ where
     SyncFn: Fn(&SyncRequest) -> Result<SyncResponse, Error> + Send + Sync + 'static,
     ErrorFn: Fn(&SyncRequest, Error) -> (Value, Option<Duration>) + Send + Sync + 'static,
 {
-
     fn sync(&self, req: &SyncRequest) -> SyncResponse {
         let (sync_fun, handle_error) = self;
         match sync_fun(req) {
             Ok(resp) => resp,
             Err(err) => {
                 let (status, resync) = handle_error(req, err);
-                SyncResponse { status, resync, children: Vec::new() }
+                SyncResponse {
+                    status,
+                    resync,
+                    children: Vec::new(),
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! // this function will block the current thread indifinitely while the operator runs
 //! run_operator(operator_config, handle_sync);
 //!
-//! fn handle_sync(request: &SyncRequest) -> Result<SyncResponse, Error> {
+//! fn handle_sync(request: &SyncRequest) -> SyncResponse {
 //!     // for this tiny example, we'll only create a single Pod. You can also use any of the types
 //!     // defined in the k8s_openapi crate, which has serializable structs for all the usual resources
 //!     let pod = json!({
@@ -53,11 +53,11 @@
 //!         // normally, we'd derive the status by taking a look at the existing `children` in the request
 //!         "message": "everything looks good here!",
 //!     });
-//!     Ok(SyncResponse {
+//!     SyncResponse {
 //!         status,
 //!         children: vec![pod],
 //!         resync: None,
-//!     })
+//!     }
 //! }
 //! ```
 //!

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -314,6 +314,9 @@ impl CappedBackoff {
                 // this disables the exponential backoff.
                 exp.randomization_factor = 0.0;
                 exp.multiplier = 1.0;
+                // ensure resync requested is guaranteed.
+                exp.initial_interval = 0;
+                exp.max_interval = Duration::from_secs(0);
             }
         };
         exp.reset();

--- a/src/runner/testkit/mod.rs
+++ b/src/runner/testkit/mod.rs
@@ -550,7 +550,7 @@ struct SyncRecord {
     finalize_count: usize,
     finalize_errors: usize,
     last_sync_request: Option<SyncRequest>,
-    last_sync_response: Option<Result<SyncResponse, String>>,
+    last_sync_response: Option<SyncResponse>,
     last_finalize_request: Option<SyncRequest>,
     last_finalize_response: Option<Result<FinalizeResponse, String>>,
 }
@@ -561,16 +561,8 @@ impl SyncRecord {
         self.last_sync_request = Some(req.clone());
     }
 
-    fn sync_finished(&mut self, resp: &Result<SyncResponse, Error>) {
-        match resp.as_ref() {
-            Ok(response) => {
-                self.last_sync_response = Some(Ok(response.clone()));
-            }
-            Err(e) => {
-                self.sync_errors += 1;
-                self.last_sync_response = Some(Err(format!("Handler error: {}", e)));
-            }
-        }
+    fn sync_finished(&mut self, resp: &SyncResponse) {
+        self.last_sync_response = Some(resp.clone());
     }
 
     fn finalize_started(&mut self, req: &SyncRequest) {
@@ -648,7 +640,7 @@ impl InstrumentedHandler {
 }
 
 impl Handler for InstrumentedHandler {
-    fn sync(&self, req: &SyncRequest) -> Result<SyncResponse, Error> {
+    fn sync(&self, req: &SyncRequest) -> SyncResponse {
         let InstrumentedHandler {
             ref wrapped,
             ref records,


### PR DESCRIPTION
Fixes #3 

Implementation notes:
* Repeated resync calls get exponential backoff with randomized jitter applied. These parameters can be tuned but unsure how to expose them without just bloating the configuration interface excessively. I suspect the best option is to pick some good defaults and leave it at that.
* `Handler.sync` no longer returns a `Result<SyncResponse, Error>`. See the discussion on #3 for details. A new impl has been added for `Handler` that sets up an error free `sync` function given a way to handle the possible errors from a fallible `sync` function. 

This is a breaking change in both spec and semantics.