### PR TITLE
Add StatefulSet to k8s types

### DIFF
--- a/src/k8s_types.rs
+++ b/src/k8s_types.rs
@@ -208,7 +208,8 @@ def_types! {
             ControllerRevision ~ controllerrevisions,
             DaemonSet ~ daemonsets,
             Deployment ~ deployments,
-            ReplicaSet ~ replicasets
+            ReplicaSet ~ replicasets,
+            StatefulSet ~ statefulsets
         ]
     ]
 }


### PR DESCRIPTION
I found I needed the kubernetes `StatefulSet` as one of my children, so I added it to apps. 