### PR TITLE
Handler errors redux

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
           export KUBECONFIG="$(kind get kubeconfig-path)"
           kubectl cluster-info
           kubectl apply -f tests/resources/
-          cargo test --features 'testkit test'
+          cargo test --all-features
 
   fmt:
     name: Rustfmt
@@ -50,4 +50,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: "--features testkit -- -D warnings"
+          args: "--all-features -- -D warnings"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ chrono = "^0.4"
 [features]
 default = []
 testkit = []
+failable = []
 # The reason we do this is because doctests don't get cfg(test)
 # See: https://github.com/rust-lang/cargo/issues/4669
 test = []
@@ -54,3 +55,7 @@ test = []
 [[test]]
 name = "integration_tests"
 required-features = ["testkit"]
+
+[[examples]]
+name = "temp-namespace"
+required-features = ["failable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ backoff = "0.1.6"
 [dev-dependencies]
 k8s-openapi = { version = "0.6.0", default-features = false, features = ["v1_15"] }
 env_logger = "0.7.1"
+chrono = "^0.4"
 
 [features]
 default = []

--- a/docs/guide/handler-sync.md
+++ b/docs/guide/handler-sync.md
@@ -92,6 +92,12 @@ impl Handler for MyHandler {
 }
 ```
 
+## Failable Handlers
+
+This page describes the base `Handler` trait and how to use it. For operators that need to perform some custom validation or
+connect to external systems, you may want to check out the `FailableHandler` trait [described here](../reference/failable-handlers.md)
+as an alternative.
+
 # Next
 
 Put it all together and [run your operator](running.md)!

--- a/docs/reference/failable-handlers.md
+++ b/docs/reference/failable-handlers.md
@@ -1,0 +1,129 @@
+# Failable Handlers
+
+For many `Handler` impls, the only error conditions you need to handle are from
+(de)serialization. For those, it's fine to just return the errors from your `sync` function. But
+some handlers may perform custom validation of parent resources, or need to connect to external
+systems like a database or web service. For these, more sophisticated error handling is
+desirable, so that the operator can populate the status of the parent with details about the
+error.
+
+The optional `failable` feature is designed to help with implementing handlers that want to
+recover from errors by adding error description to the status of the parent. This can be enabled
+by declaring the roperator dependency like so in your `Cargo.toml`:
+
+```toml
+[dependencies]
+roperator = { version = "^0.2", features = ["failable"] }
+```
+
+This enables this `roperator::handler::failable` module, which contains helpers for implementing
+`Handler`s that also do some error handling. The main interface for your operator is and always
+will be the `Handler` trait. The types exposed in the `failable` module just make it easier to
+implement `Handler` in a way that allows most errors to be dealt with by describing the error in
+the `status` of the parent resource.
+
+## Implement the `FailableHandler` trait
+
+The [`FailableHandler` trait](https://docs.rs/roperator/latest/roperator/handler/failable/trait.FailableHandler.html)
+breaks down your sync and finalize functions into multiple steps, instead of building the whole
+`SyncResponse` all at once. The `FailableHandler` trait defines three separate functions that go
+into handling a sync request, `validate`, `sync_children`, and `determine_status`. These are each
+called in sequence in order to build the `SyncResponse`. If either `validate` or `sync_children`
+returns an error, then the error will be passed to the `determine_status` function, so that you
+can desciribe the error in the status.
+
+### Example:
+
+```rust
+use roperator::handler::failable::{FailableHandler, HandlerResult, DefaultFailableHandler};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+/// Struct that corresponds to your CRD type. The parent is deserailized as this type in the `validate` function
+#[derive(Deserialize, Debug)]
+struct MyCrdType {
+    metadata: ObjectMeta,
+    spec: MyCrdSpec,
+    status: MyCrdStatus,
+}
+
+#[derive(Deserialize, Debug)]
+struct MyCrdSpec {
+    foo: String,
+    some_number: i32,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct MyCrdStatus {
+    error: Option<String>,
+    // plus whatever else you want to include in the status
+}
+
+
+struct MyHandler;
+impl FailableHandler for MyHandler {
+
+    type Validated = MyCrdType;
+
+    // we'll just pretend that `MyError` exists and implements `From<serde_json::Error>` so
+    // that we can use the `?` operator
+    type Error = MyError;
+
+    type Status = MyStatus;
+
+    fn validate(&self, request: &SyncRequest) -> Result<Self::Validated, Self::Error> {
+        // we could also do some additional custom validation if we want
+        request.deserialize_parent().map_err(|e| MyError::SerdeError(e))
+    }
+
+    // This is only called if validation is successful, and will be passed a mutable reference to the validated type
+    fn sync_children(&self, validated: &mut MyCrdType, request: &SyncRequest) -> Result<Vec<Value>, Self::Error> {
+        let child1 = try_create_child1(validated)?;
+        let child2 = try_create_child2(validated)?;
+        Ok(vec![child1, child2])
+    }
+
+    fn determine_status(&self, request: &SyncRequest, result: HandlerResult<MyCrdType, MyError>) -> Self::Status {
+        // if the result is an error variant, then we'll convert it to a string to add to the status.
+        // Note that `HandlerResult` is not a std::result::Result, and has more variants
+        let error_message = result.into_error().map(std::fmt::Display::to_string);
+
+        // normally, we might also include some information derived from the status of the child resources, too
+        MyStatus {
+            error: error_message,
+        }
+    }
+}
+```
+
+If `validate` returns an error, then `sync_children` will be skipped. This means that no new child resources will be created,
+and any existing child resources will be deleted.
+
+
+## Wrap `MyHandler` with `DefaultFailableHandler`
+
+The `FailableHandler` trait does not do anything by itself. It must be adapted to the `Handler` trait by wrapping it using
+`DefaultFailableHandler::wrap`. The `DefaultFailableHandler` drives the `FailableHandler` and also provides some optional
+additional functionality.
+
+### Example
+
+```rust
+use roperator::handler::failable::DefaultFailableHandler;
+
+fn main() {
+    // ... the usual setup to create an OperatorConfig
+    // let config = ...
+
+    // wrap the MyHandler from the previous example
+    let handler = DefaultFailableHandler::wrap(MyHandler);
+    roperator::runner::run_operator(config, handler);
+}
+```
+
+### Error Backoffs
+
+When either `validate` or `sync_children` return an error, `DefaultFailableHandler` will use it's `BackoffConfig` to determine when to re-try. This will use a backoff that grows by a multiplier with each subsequent error for the same parent. This backoff can be customized or disabled by supplying your own `BackoffConfig` to `DefaultFailableHandler::with_backoff`.
+
+### Regular Re-Syncs
+
+In addition to the normal behavior, `DefaultFailableHandler` can also re-sync at regular time intervals, even when nothing has changed. This is useful for operators that manage resources that are external to the k8s cluster. You can enable this by calling `with_regular_resync` and passing in a `std::time::Duration`.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,6 +10,10 @@ Information on creating `ClientConfig` and authenticating to the Kubernetes API 
 
 How to authenticate with GKE clusters from a development environment
 
+### [Failable Handlers](failable-handlers.md)
+
+How to use the optional `failable` feature for handlers that may return errors
+
 ### [Labels and Tracking](labels-and-tracking.md)
 
 Details on how Roperator uses labels to track Kubernetes resources

--- a/examples/temp-namespace/README.md
+++ b/examples/temp-namespace/README.md
@@ -1,0 +1,11 @@
+# Temp Namespace example Operator
+
+This example uses a CRD to represent a temporary namespace that will be deleted automatically after an expiration period. This shows off how to use time-based regular re-syncs, and also how to use the `FailableHandler` trait.
+
+To run this example:
+
+- Ensure that your kubeconfig file is updated and that the current context is pointed to a Kubernetes cluster that you have access to
+- Create the CustomResourceDefinition in your cluster using `kubectl apply -f examples/temp-namespace/crd.yaml`
+- Next, run the operator using `cargo run --example examples/temp-namespace`
+- Now use kubectl to create an instance of your EchoServer using `kubectl apply -f examples/temp-namespace/example.yaml`
+- The operator will then create the actual namespace called `my-temp-namespace`. Run `kubectl get tempns my-temp-namespace -o yaml` and you should see the `createdAt` timestamp.

--- a/examples/temp-namespace/crd.yaml
+++ b/examples/temp-namespace/crd.yaml
@@ -1,0 +1,32 @@
+# This is the CustomResourceDefinition for our EchoServer application.
+# You must create this CRD in your k8s cluster prior to running the example.
+# To do so, run: `kubectl create -f examples/echo-server/crd.yaml`
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tempnamespaces.example.roperator.com
+spec:
+  group: example.roperator.com
+  versions:
+    - name: v1alpha1
+      storage: true
+      served: true
+  scope: Cluster
+  subresources:
+    status: {}
+  names:
+    kind: TempNamespace
+    plural: tempnamespaces
+    singular: tempnamespace
+    shortNames:
+    - tempns
+  validation:
+    openAPIV3Schema:
+      type: object
+      properties:
+        spec:
+          type: object
+          properties:
+            deleteAfter:
+              description: 'duration after which to delete the namespace and everything in it. Experessed as a string with 1 or more digits followed by a single character unit of "s" (seconds), "m" (minutes), "h" (hours)'
+              type: string

--- a/examples/temp-namespace/example.yaml
+++ b/examples/temp-namespace/example.yaml
@@ -1,0 +1,9 @@
+# This is an example instance of the custom resource defined in crd.yaml
+# You need to first create the CRD using `kubectl apply -f examples/echo-server/crd.yaml` before
+# you can create this resource by using `kubectl apply -f examples/echo-server/example.yaml`
+apiVersion: example.roperator.com/v1alpha1
+kind: TempNamespace
+metadata:
+  name: my-temp-namespace
+spec:
+  deleteAfter: '10m'

--- a/examples/temp-namespace/main.rs
+++ b/examples/temp-namespace/main.rs
@@ -4,14 +4,14 @@
 //!
 //! This example uses the `DefaultFailableHandler` to wrap a `FailableHandler` impl. This
 //! provides a somewhat more opinionated and simpler interface that makes it easy to have proper
-//! error handling and visibility.
+//! error handling and visibility. This requires the "failable" feature to be enabled.
 #[macro_use]
 extern crate serde_derive;
 
 use chrono::offset::Utc;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
 use roperator::config::{ClientConfig, Credentials, KubeConfig};
-use roperator::handler::{DefaultFailableHandler, FailableHandler};
+use roperator::handler::failable::{DefaultFailableHandler, FailableHandler};
 use roperator::prelude::{k8s_types, ChildConfig, K8sType, OperatorConfig, SyncRequest};
 use roperator::serde_json::{json, Value};
 use serde::de::{self, Deserialize, Deserializer};

--- a/examples/temp-namespace/main.rs
+++ b/examples/temp-namespace/main.rs
@@ -1,0 +1,216 @@
+//! Example of using roperator to create an operator for an `TempNamespace` example Custom Resource.
+//! When an instance of the TempNamespace CRD is created, the operator will create an actual k8s
+//! namespace in response. It will automaticaly delete the namespace after the provided duration.
+//!
+//! This example uses the `DefaultFailableHandler` to wrap a `FailableHandler` impl. This
+//! provides a somewhat more opinionated and simpler interface that makes it easy to have proper
+//! error handling and visibility.
+#[macro_use]
+extern crate serde_derive;
+
+use chrono::offset::Utc;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, Time};
+use roperator::config::{ClientConfig, Credentials, KubeConfig};
+use roperator::handler::{DefaultFailableHandler, FailableHandler};
+use roperator::prelude::{k8s_types, ChildConfig, K8sType, OperatorConfig, SyncRequest};
+use roperator::serde_json::{json, Value};
+use serde::de::{self, Deserialize, Deserializer};
+use std::time::Duration;
+
+/// Name of our operator, which is automatically added as a label value in all of the child resources we create
+const OPERATOR_NAME: &str = "temp-namespace-example";
+
+/// a `K8sType` with basic info about our parent CRD
+static PARENT_TYPE: &K8sType = &K8sType {
+    api_version: "example.roperator.com/v1alpha1",
+    kind: "TempNamespace",
+    plural_kind: "tempnamespaces",
+};
+
+/// Represents an instance of the CRD that is in the kubernetes cluster.
+/// Note that this struct does not need to implement Serialize because the
+/// operator will only ever update the `status` subresource
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct TempNamespace {
+    pub metadata: ObjectMeta,
+    pub spec: TempNamespaceSpec,
+    pub status: Option<TempNamespaceStatus>,
+}
+
+impl TempNamespace {
+    fn get_time_remaining(&self) -> Option<Duration> {
+        let created_at = self
+            .status
+            .as_ref()
+            .and_then(|status| status.created_at.as_ref().map(|time| time.0))
+            .unwrap_or(Utc::now());
+
+        let elapsed = Utc::now()
+            .signed_duration_since(created_at)
+            .to_std()
+            .unwrap_or(Duration::from_secs(0));
+        if self.spec.delete_after > elapsed {
+            Some(self.spec.delete_after - elapsed)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+pub struct TempNamespaceSpec {
+    #[serde(rename = "deleteAfter", deserialize_with = "deserialize_duration")]
+    delete_after: Duration,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TempNamespaceStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<Time>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deleted_at: Option<Time>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+// Our handler implements the `FailableHandler` trait instead of implementing Handler directly.
+// This allows us to express the sync logic a little more easily, and use the
+// `DefaultFailableHandler::wrap` function to give us some reasonable defaults for error handling
+// and regular re-syncs.
+struct TempNsHandler;
+impl FailableHandler for TempNsHandler {
+    type Error = serde_json::Error;
+    type Status = TempNamespaceStatus;
+
+    fn sync_children(&self, request: &SyncRequest) -> Result<Vec<Value>, Self::Error> {
+        let temp_ns = request.deserialize_parent::<TempNamespace>()?;
+        let time_remaining = temp_ns.get_time_remaining();
+        log::info!(
+            "Namespace: '{}' has {:?} time remaining",
+            request.parent.name(),
+            time_remaining
+        );
+        if time_remaining.is_some() {
+            Ok(vec![namespace(&temp_ns)])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn determine_status(
+        &self,
+        request: &SyncRequest,
+        sync_error: Option<Self::Error>,
+    ) -> Self::Status {
+        let parent = request.deserialize_parent::<TempNamespace>().ok();
+        let time_remaining = parent.as_ref().and_then(|p| p.get_time_remaining());
+        let prev_status = parent.and_then(|p| p.status).unwrap_or_default();
+
+        let existing_namespace = request
+            .children()
+            .of_type(k8s_types::core::v1::Namespace)
+            .first();
+        let created_at = prev_status
+            .created_at
+            .clone()
+            .or_else(|| existing_namespace.as_ref().map(|_| Time(Utc::now())));
+        let deleted_at = prev_status.deleted_at.clone().or_else(|| {
+            if time_remaining.is_none() {
+                Some(Time(Utc::now()))
+            } else {
+                None
+            }
+        });
+        let error = sync_error.map(|e| format!("invalid TempNamepsace resource: {}", e));
+        TempNamespaceStatus {
+            created_at,
+            deleted_at,
+            error,
+        }
+    }
+}
+
+fn main() {
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "roperator=info,temp_namespace=debug,warn");
+    }
+    env_logger::init();
+
+    // create our operator config, which contains the type information of the parent resource and
+    // all the child resources we might create.
+    let operator_config = OperatorConfig::new(OPERATOR_NAME, PARENT_TYPE)
+        .with_child(k8s_types::core::v1::Namespace, ChildConfig::on_delete());
+
+    // This section is not necessary unless you want to run locally against a GKE cluster. This is only
+    // provided to make that easier, since it may be a common environment to test against.
+    // For most other clusters, you can just use `roperator::runner::run_operator` without providing a ClientConfig
+    let client_config_result = if let Ok(token) = std::env::var("ROPERATOR_AUTH_TOKEN") {
+        let credentials = Credentials::base64_bearer_token(token);
+        let (kubeconfig, kubeconfig_path) = KubeConfig::load().expect("failed to load kubeconfig");
+        let kubeconfig_parent_path = kubeconfig_path.parent().unwrap();
+        kubeconfig.create_client_config_with_credentials(
+            OPERATOR_NAME.to_string(),
+            kubeconfig_parent_path,
+            credentials,
+        )
+    } else {
+        ClientConfig::from_kubeconfig(OPERATOR_NAME.to_string())
+    };
+    let client_config =
+        client_config_result.expect("failed to resolve cluster data from kubeconfig");
+
+    // the call to `with_regular_resync` will ensure that our handler is invoked every minute,
+    // regardless of whether there's been a change detected. We do this so that we can check
+    // regularly to see if the namespace needs to be deleted
+    let handler =
+        DefaultFailableHandler::wrap(TempNsHandler).with_regular_resync(Duration::from_secs(30));
+    // now we run the operator, passing in our handler functions
+    let err =
+        roperator::runner::run_operator_with_client_config(operator_config, client_config, handler);
+
+    // `run_operator_with_client_config` will never return under normal circumstances, so we only need to handle the sad path here
+    log::error!("Error running operator: {}", err);
+    std::process::exit(1);
+}
+
+// returns the desired namespace resource. Nothing fancy here, just the basics
+fn namespace(parent: &TempNamespace) -> Value {
+    json!({
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+            "name": parent.metadata.name.as_ref().expect("parent name is missing"),
+        }
+    })
+}
+
+// helper to deserialize a std::time::Duration from a string representation
+fn deserialize_duration<'de, D>(deserailizer: D) -> Result<Duration, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let as_str = String::deserialize(deserailizer)?;
+
+    if as_str.len() < 2 {
+        return Err(de::Error::custom(format!(
+            "invalid duration: '{:?}'",
+            as_str
+        )));
+    }
+    let (digits, unit) = as_str.split_at(as_str.len() - 1);
+    let quantity = digits
+        .parse::<u64>()
+        .map_err(|e| de::Error::custom(format!("invalid number: '{}'", e)))?;
+    let multiplier = match unit.to_ascii_uppercase().as_str() {
+        "S" => 1,
+        "M" => 60,
+        "H" => 60 * 60,
+        "D" => 60 * 60 * 24,
+        other => return Err(de::Error::custom(format!("invalid unit: '{:?}'", other))),
+    };
+
+    Ok(Duration::from_secs(quantity * multiplier))
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,7 @@
 //! This request struct has lots of functions on it for accessing and deserializing child resources.
 
 /// Helpers for implementing handlers that may recover from their own errors
-#[cfg(feature = "failable")]
+#[cfg(any(feature = "failable", docs))]
 pub mod failable;
 
 // only expose the reqeust mod during tests.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,7 @@
 //! This request struct has lots of functions on it for accessing and deserializing child resources.
 
 /// Helpers for implementing handlers that may recover from their own errors
-/// #[cfg(feature = "failable")]
+#[cfg(feature = "failable")]
 pub mod failable;
 
 // only expose the reqeust mod during tests.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,6 +5,10 @@
 //! snapshot of the state of a given parent resource, along with any children that currently exist for it.
 //! This request struct has lots of functions on it for accessing and deserializing child resources.
 
+/// Helpers for implementing handlers that may recover from their own errors
+#[cfg(feature = "failable")]
+pub mod failable;
+
 // only expose the reqeust mod during tests.
 #[cfg(feature = "test")]
 pub mod request;
@@ -12,15 +16,12 @@ pub mod request;
 #[cfg(not(feature = "test"))]
 mod request;
 
-mod failable;
-
 use crate::error::Error;
 use serde::Serialize;
 use serde_json::Value;
 use std::fmt::{self, Debug};
 use std::time::Duration;
 
-pub use self::failable::{BackoffConfig, DefaultFailableHandler, ErrorBackoff, FailableHandler};
 pub use self::request::{RawView, RequestChildren, SyncRequest, TypedIter, TypedView};
 /// The return value from your handler function, which has the status to set for the parent, as well as any
 /// desired child resources. Any existing child resources that are **not** included in this response **will be deleted**.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -12,14 +12,16 @@ pub mod request;
 #[cfg(not(feature = "test"))]
 mod request;
 
+mod failable;
+
 use crate::error::Error;
 use serde::Serialize;
 use serde_json::Value;
 use std::fmt::{self, Debug};
 use std::time::Duration;
 
+pub use self::failable::{BackoffConfig, DefaultFailableHandler, ErrorBackoff, FailableHandler};
 pub use self::request::{RawView, RequestChildren, SyncRequest, TypedIter, TypedView};
-
 /// The return value from your handler function, which has the status to set for the parent, as well as any
 /// desired child resources. Any existing child resources that are **not** included in this response **will be deleted**.
 #[derive(Deserialize, Serialize, Clone, PartialEq)]
@@ -79,6 +81,9 @@ impl SyncResponse {
         })
     }
 
+    /// sets the `resync` field of the response to `Some(duration)`, which instructs roperator
+    /// to invoke your sync handler after the given time period, regardless of whether any
+    /// changes are observed.
     pub fn resync_after(&mut self, duration: Duration) {
         self.resync = Some(duration);
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,7 +6,7 @@
 //! This request struct has lots of functions on it for accessing and deserializing child resources.
 
 /// Helpers for implementing handlers that may recover from their own errors
-#[cfg(feature = "failable")]
+/// #[cfg(feature = "failable")]
 pub mod failable;
 
 // only expose the reqeust mod during tests.

--- a/src/handler/failable.rs
+++ b/src/handler/failable.rs
@@ -547,7 +547,7 @@ impl<H: FailableHandler> Handler for DefaultFailableHandler<H> {
             .inner
             .finalize(request)
             .err()
-            .map(|e| HandlerResult::FinalizeFailed(e))
+            .map(HandlerResult::FinalizeFailed)
             .unwrap_or(HandlerResult::FinalizeSuccess);
 
         let retry = if result.is_error() {

--- a/src/handler/failable.rs
+++ b/src/handler/failable.rs
@@ -1,0 +1,546 @@
+//! Traits and helpers for creating `Handler` implementations that perform some error
+//! handling. Most use cases are covered by implementing the `FailableHandler` trait
+//! and wrapping your impl in a `DefaultFalableHandler`.
+use crate::handler::{Error, FinalizeResponse, Handler, SyncRequest, SyncResponse};
+
+use serde_json::Value;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// Configuration that determines the behavior of an exponential backoff.
+/// The `Default` impl will use an `initial_interval` of 500 milliseconds,
+/// a `max_interval` of 10 minutes, a multiplier of 1.5, and it will never
+/// "give up".
+#[derive(Debug, Clone)]
+pub struct BackoffConfig {
+    /// The starting backoff for the first error. For each subsequent error,
+    /// this interval will be multiplied by the `multiplier` to determine the
+    /// next backoff, before applying a pseudorandom jitter of +/- 20% of the
+    /// duration.
+    pub initial_interval: Duration,
+
+    /// The maximum interval that will ever be returned by a backoff
+    pub max_interval: Duration,
+
+    /// If this is set to `Some`, then we will no discontinue any retries
+    /// after the given duration has elapsed. This duration is measured from the
+    /// time of the first error occurrence, and this will be reset after a single
+    /// success. If this is None, then we will continue to retry indefinitely.
+    pub give_up_after: Option<Duration>,
+
+    /// The multiplier to apply to the backoff on each subsequent error. The
+    /// backoff interval will continue to grow until it reaches the `max_interval`
+    /// or there is at least one success.
+    pub multiplier: f64,
+
+    /// Applies a random jitter to each backoff duration, to vary it by at most the
+    /// given multiplier in either direction. This is typically desirable because it
+    /// can help spread out reties in cases where many parents all encounter errors
+    /// at around the same time.
+    pub randomization_factor: f64,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> BackoffConfig {
+        BackoffConfig {
+            initial_interval: Duration::from_millis(500),
+            max_interval: Duration::from_secs(600),
+            give_up_after: None,
+            multiplier: 1.5,
+            randomization_factor: 0.5,
+        }
+    }
+}
+
+impl BackoffConfig {
+    /// Sets backoff to always be at a fixed interval that will never increase or
+    /// decrease. Randomization will be disabled as well, so that the interval is
+    /// always the same.
+    ///
+    /// ```rust
+    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use std::time::Duration;
+    /// # let request = &roperator::handler::request::test_request();
+    /// let interval = Duration::from_millis(500);
+    /// let config = BackoffConfig::fixed_interval(interval);
+    /// let error_backoff = ErrorBackoff::new(config);
+    ///
+    /// for _ in 0..10 {
+    ///     let backoff_duration = error_backoff.next_error_backoff(request);
+    ///     assert_eq!(Some(interval), backoff_duration);
+    /// }
+    /// ```
+    pub fn fixed_interval(interval: Duration) -> BackoffConfig {
+        BackoffConfig {
+            initial_interval: interval,
+            max_interval: interval,
+            give_up_after: None,
+            multiplier: 1.0,
+            randomization_factor: 0.0,
+        }
+    }
+
+    /// Disables retries entirely. Using this configuration will cause
+    /// `ErrorBackoff::next_error_backoff` to always return `None`.
+    ///
+    /// ```rust
+    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use std::time::Duration;
+    /// # let request = &roperator::handler::request::test_request();
+    /// let interval = Duration::from_millis(500);
+    /// let config = BackoffConfig::never_retry();
+    /// let error_backoff = ErrorBackoff::new(config);
+    ///
+    /// for _ in 0..10 {
+    ///     let backoff_duration = error_backoff.next_error_backoff(request);
+    ///     assert!(backoff_duration.is_none());
+    /// }
+    /// ```
+    pub fn never_retry() -> BackoffConfig {
+        BackoffConfig {
+            initial_interval: Duration::from_millis(500),
+            give_up_after: Some(Duration::from_millis(0)),
+            randomization_factor: 0.0,
+            ..Default::default()
+        }
+    }
+
+    /// Disables the randomization of backoff intervals. By default, backoff intervals will vary
+    /// by a random amount in the range of +/-50%. This is typically what you want, since it can
+    /// help space out retries if there's a case where errors occur for many resources at the same
+    /// time. Disabling this behavior can be useful, though, especially for testing.
+    pub fn disable_randomization(mut self) -> Self {
+        self.randomization_factor = 0.0;
+        self
+    }
+
+    fn new_backoff(&self) -> backoff::ExponentialBackoff {
+        let start_time = if Some(Duration::from_millis(0)) == self.give_up_after {
+            std::time::Instant::now() - Duration::from_millis(500)
+        } else {
+            std::time::Instant::now()
+        };
+        backoff::ExponentialBackoff {
+            initial_interval: self.initial_interval,
+            current_interval: self.initial_interval,
+            max_interval: self.max_interval,
+            multiplier: self.multiplier,
+            max_elapsed_time: self.give_up_after,
+            randomization_factor: self.randomization_factor,
+            start_time,
+            ..Default::default()
+        }
+    }
+}
+
+/// A helper to track the state of error backoffs for each parent resource. This can be used
+/// by a handler in order to recover from errors and compute the retry backoff on a per-parent
+/// basis. For most use cases, you can implemet `FailableHandler` and use `DefaultFailableHandler`,
+/// which will apply the error backoff automatically. This struct is exposed so that you could also
+/// use it in your own Handler impl for cases where you need more control over error handling and
+/// recovery.
+///
+/// Example:
+///
+/// ```rust
+/// use roperator::handler::{Handler, ErrorBackoff, SyncRequest, SyncResponse};
+/// use roperator::error::Error;
+/// use std::io;
+///
+/// # let request = &roperator::handler::request::test_request();
+/// fn try_handle_sync(_req: &SyncRequest) -> Result<SyncResponse, Error> {
+///     Err(Error::from(io::Error::new(io::ErrorKind::Other, "oh no, an error!")))
+/// }
+///
+/// struct ErrorRecoveringHandler(ErrorBackoff);
+///
+/// impl Handler for ErrorRecoveringHandler {
+///
+///     fn sync(&self, req: &SyncRequest) -> Result<SyncResponse, Error> {
+///
+///         // if `try_handle_sync` fails, we'll format the error message and put it in the
+///         // status, and then retry the sync after a backoff period
+///         match try_handle_sync(req) {
+///             Ok(resp) => {
+///                 self.0.reset_backoff(req);
+///                 Ok(resp)
+///             }
+///             Err(err) => {
+///                 let backoff = self.0.next_error_backoff(req);
+///                 let status = serde_json::json!({
+///                     "error": err.to_string(),
+///                 });
+///                 Ok(SyncResponse {
+///                     status,
+///                     resync: backoff,
+///                     children: Vec::new(),
+///                 })
+///             }
+///         }
+///     }
+/// }
+///
+/// let handler = ErrorRecoveringHandler(ErrorBackoff::default());
+/// let response = handler.sync(request).expect("should always return Ok");
+/// assert!(response.resync.is_some());
+///
+/// ```
+#[derive(Debug, Default)]
+pub struct ErrorBackoff {
+    backoff_state: Arc<Mutex<HashMap<String, backoff::ExponentialBackoff>>>,
+    backoff_config: BackoffConfig,
+}
+
+impl ErrorBackoff {
+    /// Constructs a new `ErrorBackoff` from the given configuration.
+    ///
+    /// Example:
+    ///
+    /// ```rust
+    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use std::time::Duration;
+    ///
+    /// let config = BackoffConfig {
+    ///     initial_interval: Duration::from_millis(50),
+    ///     multiplier: 2.0,
+    ///     ..Default::default()
+    /// };
+    /// let _backoff = ErrorBackoff::new(config);
+    /// ```
+    pub fn new(backoff_config: BackoffConfig) -> ErrorBackoff {
+        ErrorBackoff {
+            backoff_config,
+            backoff_state: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns the next backoff for the parent in the given request. The first time
+    /// this is called, it will return a backoff based on the `initial_interval`. It
+    /// will be increased by the multiplier on each subsequent call, until `reset_backoff`
+    /// is called for the parent.
+    ///
+    /// ```rust
+    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// # let request = &roperator::handler::request::test_request();
+    /// // disable randomization to make backoff durations deterministic for tests
+    /// let error_backoff = ErrorBackoff::new(BackoffConfig::default().disable_randomization());
+    ///
+    /// let mut duration = error_backoff.next_error_backoff(request).unwrap();
+    /// for _ in 0..10 {
+    ///     let next = error_backoff.next_error_backoff(request).unwrap();
+    ///     assert!(next > duration);
+    ///     duration = next;
+    /// }
+    /// ```
+    pub fn next_error_backoff(&self, req: &SyncRequest) -> Option<Duration> {
+        use backoff::backoff::Backoff;
+
+        let ErrorBackoff {
+            ref backoff_state,
+            ref backoff_config,
+        } = *self;
+        let uid = req.parent.uid();
+        let mut backoffs = backoff_state.lock().unwrap();
+        if !backoffs.contains_key(uid) {
+            let backoff = backoff_config.new_backoff();
+            backoffs.insert(uid.to_owned(), backoff);
+        }
+        let bo = backoffs.get_mut(uid).unwrap();
+        bo.next_backoff()
+    }
+
+    /// Resets the error backoff for the given parent. This should be called after _every_
+    /// sucessful sync or finalize call to ensure that the error state gets cleared.
+    /// After this is called, the next error duration will go back down to the `initial_interval`.
+    ///
+    /// ```rust
+    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// # let request = &roperator::handler::request::test_request();
+    /// let config = BackoffConfig::default().disable_randomization();
+    /// let error_backoff = ErrorBackoff::new(config.clone());
+    ///
+    /// let mut duration = error_backoff.next_error_backoff(request).unwrap();
+    /// for _ in 0..20 {
+    ///     duration = error_backoff.next_error_backoff(request).unwrap();
+    /// }
+    /// assert!(duration > config.initial_interval);
+    ///
+    /// error_backoff.reset_backoff(request);
+    /// duration = error_backoff.next_error_backoff(request).unwrap();
+    /// assert_eq!(config.initial_interval, duration);
+    /// ```
+    pub fn reset_backoff(&self, req: &SyncRequest) {
+        let uid = req.parent.uid();
+        let mut backoffs = self.backoff_state.lock().unwrap();
+        backoffs.remove(uid);
+    }
+}
+
+/// An optional trait for creating handlers that want to recover from their own errors.
+/// This provides an opinionated base that should work well for most operators.
+/// Sync and finalize operations are broken down into separate steps, one for the action
+/// itself, and another for determining the status. If `sync_children` returns an `Err`
+/// then the error will be passed to `determine_status` so that it can be described in the
+/// status of the parent. Same goes for `finalize`. Like the base `Handler` trait, this trait
+/// provides a default implementation of `finalize` for common cases where no special finalization
+/// logic is required.
+///
+/// Unlike the base `Handler` trait, `FailableHandler` impls may use any eror type they wish,
+/// even those that are not `Send` or `'static`.
+pub trait FailableHandler: Send + Sync + 'static {
+    type Error: Debug;
+    type Status: serde::Serialize + serde::de::DeserializeOwned;
+
+    /// Returns the list of desired children for this parent. This function will be called
+    /// in the same was as the base `sync` function, except that it only returns the list of
+    /// children instead of the entire response.
+    fn sync_children(&self, req: &SyncRequest) -> Result<Vec<Value>, Self::Error>;
+
+    /// Finalize this parent. The default implementation simply allows the deletion to proceed
+    /// as normal.
+    fn finalize(&self, _req: &SyncRequest) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Determines the current status of the parent based on the current state of the child
+    /// resources and whether an error was returned by `sync_children` or `finalize`. If an
+    /// error was returned, then it will be passed to this function so that it can be described
+    /// in the status.
+    fn determine_status(&self, req: &SyncRequest, error: Option<Self::Error>) -> Self::Status;
+}
+
+impl<Syncf, Sf, Status, E> FailableHandler for (Syncf, Sf)
+where
+    E: Debug,
+    Status: serde::Serialize + serde::de::DeserializeOwned,
+    Syncf: Fn(&SyncRequest) -> Result<Vec<Value>, E> + Send + Sync + 'static,
+    Sf: Fn(&SyncRequest, Option<E>) -> Status + Send + Sync + 'static,
+{
+    type Error = E;
+    type Status = Status;
+
+    fn sync_children(&self, req: &SyncRequest) -> Result<Vec<Value>, Self::Error> {
+        (self.0)(req)
+    }
+
+    fn determine_status(&self, req: &SyncRequest, error: Option<Self::Error>) -> Self::Status {
+        (self.1)(req, error)
+    }
+}
+
+/// An opinionated and batteries-included helper for implementing Handlers that can recover from
+/// errors by setting a status on the parent that describes the error. This struct wraps a
+/// `FailableHandler` and adapts it to the `Handler` trait.
+///
+/// Example:
+///
+/// ```rust,no_run
+/// use roperator::handler::{DefaultFailableHandler, SyncRequest};
+/// use roperator::error::Error;
+/// use serde::{Serialize, Deserialize};
+/// use std::time::Duration;
+/// use serde_json::{json, Value};
+///
+/// let sync_children: fn(&SyncRequest) -> Result<Vec<Value>, Error> = |req| {
+///     Ok(vec![
+///         json!({
+///             "apiVersion": "v1",
+///             "kind": "Pod",
+///             // omitted for the sake of brevity
+///         })
+///     ])
+/// };
+/// let determine_status = |req: &SyncRequest, err: Option<Error>| {
+///     let error_json = err.as_ref()
+///         .map(|_| Value::from("omg there was an error"))
+///         .unwrap_or(Value::Null);
+///     json!({
+///         "ok": err.is_none(),
+///         "error": error_json,
+///     })
+/// };
+/// let handler = DefaultFailableHandler::wrap((sync_children, determine_status))
+///     .with_regular_resync(Duration::from_secs(300));
+/// ```
+pub struct DefaultFailableHandler<H: FailableHandler> {
+    inner: H,
+    error_backoff: ErrorBackoff,
+    regular_resync: Option<Duration>,
+}
+
+impl<F: FailableHandler> DefaultFailableHandler<F> {
+    /// Wraps a `FailableHandler` to provide a default implementation of `Handler`. The returned
+    /// handler will use the default exponential backoff.
+    pub fn wrap(failable: F) -> DefaultFailableHandler<F> {
+        DefaultFailableHandler::new(failable, BackoffConfig::default(), None)
+    }
+
+    /// Complete constructor for creating a Handler that uses the given `backoff_config`.
+    ///
+    /// The `regular_resync` parameter allows the handler to resync on a regular repeating interval,
+    /// even when no error occurs. This is useful for cases where the operator needs to sync with
+    /// some external resource outside of the kuberentes cluster. If it is `Some`, then `sync` will
+    /// be called regularly on the given interval, even when there is no change to the parent or
+    /// children. If `None` then `sync` will only be called when there is a change to the parent
+    /// or any child resource.
+    pub fn new(
+        failable: F,
+        backoff_config: BackoffConfig,
+        regular_resync: Option<Duration>,
+    ) -> DefaultFailableHandler<F> {
+        DefaultFailableHandler {
+            inner: failable,
+            error_backoff: ErrorBackoff::new(backoff_config),
+            regular_resync,
+        }
+    }
+
+    /// Sets this handler to re-sync at the given regular interval, even when there is no change
+    /// to the parent or any child resources. This is useful for cases where the operator needs
+    /// to sync with some external resource outside of the kuberentes cluster.
+    pub fn with_regular_resync(mut self, resync_interval: Duration) -> Self {
+        self.regular_resync = Some(resync_interval);
+        self
+    }
+
+    /// Sets the backoff configuration to use for handling errors
+    pub fn with_backoff(mut self, backoff_config: BackoffConfig) -> Self {
+        self.error_backoff.backoff_config = backoff_config;
+        self
+    }
+}
+
+impl<H: FailableHandler> Handler for DefaultFailableHandler<H> {
+    fn sync(&self, request: &SyncRequest) -> Result<SyncResponse, Error> {
+        let (error, children, resync) = match self.inner.sync_children(request) {
+            Ok(kids) => {
+                self.error_backoff.reset_backoff(request);
+                (None, kids, self.regular_resync)
+            }
+            Err(err) => {
+                log::error!(
+                    "sync_children for parent: {} returned error: {:?}",
+                    request.parent.get_object_id(),
+                    err
+                );
+                let duration = self.error_backoff.next_error_backoff(request);
+                (Some(err), Vec::new(), duration)
+            }
+        };
+
+        let status = self.inner.determine_status(request, error);
+
+        // if there's a serialization error, then we'll rely on roperator's builtin backoff.
+        // These error conditions are expected to be pretty rare.
+        let status_json = serde_json::to_value(status).map_err(|err| {
+            log::error!(
+                "Failed to serialize status of parent: {}, err: {:?}",
+                request.parent.get_object_id(),
+                err
+            );
+            Error::from(err)
+        })?;
+
+        Ok(SyncResponse {
+            resync,
+            children,
+            status: status_json,
+        })
+    }
+
+    fn finalize(&self, request: &SyncRequest) -> Result<FinalizeResponse, Error> {
+        let error = self.inner.finalize(request).err();
+
+        let retry = if let Some(err) = error.as_ref() {
+            log::error!(
+                "Failed to finalize parent: {}, err: {:?}",
+                request.parent.get_object_id(),
+                err
+            );
+            self.error_backoff.next_error_backoff(request)
+        } else {
+            self.error_backoff.reset_backoff(request);
+            None
+        };
+        let status_struct = self.inner.determine_status(request, error);
+        let status = serde_json::to_value(status_struct).map_err(|err| {
+            log::error!(
+                "Failed to serialize status of parent: {}, err: {:?}",
+                request.parent.get_object_id(),
+                err
+            );
+            Error::from(err)
+        })?;
+        Ok(FinalizeResponse { status, retry })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::handler::request::{test_request, SyncRequest};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+    struct TestStatus {
+        error: Option<String>,
+    }
+
+    #[derive(Debug)]
+    struct TestError;
+
+    #[test]
+    fn backoff_is_reset_after_successful_sync() {
+        let return_error = Arc::new(AtomicBool::new(true));
+        let error_control = return_error.clone();
+        let status_error = return_error.clone();
+        let sync_fun = move |_req: &SyncRequest| {
+            if return_error.load(Ordering::SeqCst) {
+                Err(TestError)
+            } else {
+                Ok(Vec::<Value>::new())
+            }
+        };
+        let status_fun = move |_req: &SyncRequest, err: Option<TestError>| {
+            let expected_error = status_error.load(Ordering::SeqCst);
+            assert_eq!(expected_error, err.is_some());
+            let error = err.map(|_| "omg there was an error".to_owned());
+            TestStatus { error }
+        };
+
+        let backoff_config = BackoffConfig::default().disable_randomization();
+        let handler = DefaultFailableHandler::wrap((sync_fun, status_fun))
+            .with_backoff(backoff_config.clone());
+
+        let request = &test_request();
+
+        for i in 0..5 {
+            let resp = handler.sync(request).expect("handler returned err");
+            assert!(resp.resync.is_some());
+            if i == 0 {
+                assert_eq!(backoff_config.initial_interval, resp.resync.unwrap());
+            } else {
+                assert!(resp.resync.unwrap() > backoff_config.initial_interval);
+            }
+            assert!(resp.children.is_empty());
+            let expected_status = serde_json::json!({
+                "error": "omg there was an error"
+            });
+            assert_eq!(expected_status, resp.status);
+        }
+
+        error_control.store(false, Ordering::SeqCst);
+
+        let resp = handler.sync(request).expect("handler returned an error");
+        assert!(resp.resync.is_none());
+
+        // now trigger another error and assert that the resync interval has gone back down
+        error_control.store(true, Ordering::SeqCst);
+        let resp = handler.sync(request).expect("handler returned an error");
+        assert_eq!(Some(backoff_config.initial_interval), resp.resync);
+    }
+}

--- a/src/handler/failable.rs
+++ b/src/handler/failable.rs
@@ -61,7 +61,7 @@ impl BackoffConfig {
     /// always the same.
     ///
     /// ```rust
-    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use roperator::handler::failable::{BackoffConfig, ErrorBackoff};
     /// use std::time::Duration;
     /// # let request = &roperator::handler::request::test_request();
     /// let interval = Duration::from_millis(500);
@@ -87,7 +87,7 @@ impl BackoffConfig {
     /// `ErrorBackoff::next_error_backoff` to always return `None`.
     ///
     /// ```rust
-    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use roperator::handler::failable::{BackoffConfig, ErrorBackoff};
     /// use std::time::Duration;
     /// # let request = &roperator::handler::request::test_request();
     /// let interval = Duration::from_millis(500);
@@ -146,7 +146,8 @@ impl BackoffConfig {
 /// Example:
 ///
 /// ```rust
-/// use roperator::handler::{Handler, ErrorBackoff, SyncRequest, SyncResponse};
+/// use roperator::handler::{Handler, SyncRequest, SyncResponse};
+/// use roperator::handler::failable::ErrorBackoff;
 /// use roperator::error::Error;
 /// use std::io;
 ///
@@ -200,7 +201,7 @@ impl ErrorBackoff {
     /// Example:
     ///
     /// ```rust
-    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use roperator::handler::failable::{BackoffConfig, ErrorBackoff};
     /// use std::time::Duration;
     ///
     /// let config = BackoffConfig {
@@ -223,7 +224,7 @@ impl ErrorBackoff {
     /// is called for the parent.
     ///
     /// ```rust
-    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use roperator::handler::failable::{BackoffConfig, ErrorBackoff};
     /// # let request = &roperator::handler::request::test_request();
     /// // disable randomization to make backoff durations deterministic for tests
     /// let error_backoff = ErrorBackoff::new(BackoffConfig::default().disable_randomization());
@@ -257,7 +258,7 @@ impl ErrorBackoff {
     /// After this is called, the next error duration will go back down to the `initial_interval`.
     ///
     /// ```rust
-    /// use roperator::handler::{BackoffConfig, ErrorBackoff};
+    /// use roperator::handler::failable::{BackoffConfig, ErrorBackoff};
     /// # let request = &roperator::handler::request::test_request();
     /// let config = BackoffConfig::default().disable_randomization();
     /// let error_backoff = ErrorBackoff::new(config.clone());
@@ -338,7 +339,8 @@ where
 /// Example:
 ///
 /// ```rust,no_run
-/// use roperator::handler::{DefaultFailableHandler, SyncRequest};
+/// use roperator::handler::SyncRequest;
+/// use roperator::handler::failable::DefaultFailableHandler;
 /// use roperator::error::Error;
 /// use serde::{Serialize, Deserialize};
 /// use std::time::Duration;

--- a/src/handler/failable.rs
+++ b/src/handler/failable.rs
@@ -1,6 +1,9 @@
 //! Traits and helpers for creating `Handler` implementations that perform some error
 //! handling. Most use cases are covered by implementing the `FailableHandler` trait
 //! and wrapping your impl in a `DefaultFalableHandler`.
+//!
+//!
+//! **This module is only available when the `failable` feature is enabled in your Cargo.toml**
 use crate::handler::{Error, FinalizeResponse, Handler, SyncRequest, SyncResponse};
 
 use serde_json::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! // this function will block the current thread indifinitely while the operator runs
 //! run_operator(operator_config, handle_sync);
 //!
-//! fn handle_sync(request: &SyncRequest) -> SyncResponse {
+//! fn handle_sync(request: &SyncRequest) -> Result<SyncResponse, Error> {
 //!     // for this tiny example, we'll only create a single Pod. You can also use any of the types
 //!     // defined in the k8s_openapi crate, which has serializable structs for all the usual resources
 //!     let pod = json!({
@@ -53,11 +53,11 @@
 //!         // normally, we'd derive the status by taking a look at the existing `children` in the request
 //!         "message": "everything looks good here!",
 //!     });
-//!     SyncResponse {
+//!     Ok(SyncResponse {
 //!         status,
 //!         children: vec![pod],
 //!         resync: None,
-//!     }
+//!     })
 //! }
 //! ```
 //!

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -75,7 +75,7 @@ async fn private_handle_sync(
         );
         Ok(Some(Duration::from_secs(0)))
     } else {
-        let (request, response) = {
+        let (request, result) = {
             tokio_executor::blocking::run(move || {
                 let result = handler.sync(&request);
                 log::debug!(
@@ -87,6 +87,9 @@ async fn private_handle_sync(
             })
             .await
         };
+        let response = result.map_err(|err| {
+            UpdateError::HandlerError(err)
+        })?;
         let resync = response.resync;
         update_all(request, response, client, runtime_config).await?;
         Ok(resync)

--- a/src/runner/reconcile/sync.rs
+++ b/src/runner/reconcile/sync.rs
@@ -87,9 +87,7 @@ async fn private_handle_sync(
             })
             .await
         };
-        let response = result.map_err(|err| {
-            UpdateError::HandlerError(err)
-        })?;
+        let response = result.map_err(|err| UpdateError::HandlerError(err))?;
         let resync = response.resync;
         update_all(request, response, client, runtime_config).await?;
         Ok(resync)

--- a/src/runner/testkit/mod.rs
+++ b/src/runner/testkit/mod.rs
@@ -550,7 +550,7 @@ struct SyncRecord {
     finalize_count: usize,
     finalize_errors: usize,
     last_sync_request: Option<SyncRequest>,
-    last_sync_response: Option<SyncResponse>,
+    last_sync_response: Option<Result<SyncResponse, String>>,
     last_finalize_request: Option<SyncRequest>,
     last_finalize_response: Option<Result<FinalizeResponse, String>>,
 }
@@ -561,8 +561,16 @@ impl SyncRecord {
         self.last_sync_request = Some(req.clone());
     }
 
-    fn sync_finished(&mut self, resp: &SyncResponse) {
-        self.last_sync_response = Some(resp.clone());
+    fn sync_finished(&mut self, resp: &Result<SyncResponse, Error>) {
+        match resp.as_ref() {
+            Ok(response) => {
+                self.last_sync_response = Some(Ok(response.clone()));
+            }
+            Err(err) => {
+                self.sync_errors += 1;
+                self.last_sync_response = Some(Err(err.to_string()));
+            }
+        }
     }
 
     fn finalize_started(&mut self, req: &SyncRequest) {
@@ -640,7 +648,7 @@ impl InstrumentedHandler {
 }
 
 impl Handler for InstrumentedHandler {
-    fn sync(&self, req: &SyncRequest) -> SyncResponse {
+    fn sync(&self, req: &SyncRequest) -> Result<SyncResponse, Error> {
         let InstrumentedHandler {
             ref wrapped,
             ref records,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -113,7 +113,7 @@ fn operator_reconciles_a_parent_with_a_child() {
         expected_child,
         Duration::from_secs(15),
     );
-    testkit.delete_parent(&id);
+    testkit.delete_parent(&id, Duration::from_secs(10));
     testkit.assert_resource_deleted_eventually(CHILD_ONE_TYPE, &id, Duration::from_secs(30));
 }
 
@@ -240,7 +240,7 @@ fn operator_retries_finalize_when_response_retry_is_some() {
         expected_parent_fields,
         Duration::from_secs(5),
     );
-    testkit.delete_parent(&id);
+    testkit.delete_parent(&id, Duration::from_secs(10));
 
     testkit.assert_resource_deleted_eventually(PARENT_TYPE, &id, Duration::from_secs(30));
     testkit.assert_resource_deleted_eventually(CHILD_ONE_TYPE, &id, Duration::from_secs(20));
@@ -445,17 +445,6 @@ impl<T: Handler> Handler for ReturnErrorHandler<T> {
             Err(Box::new(MockHandlerError(index)))
         } else {
             self.delegate.sync(req)
-        }
-    }
-
-    fn finalize(&self, req: &SyncRequest) -> Result<FinalizeResponse, Error> {
-        if self.should_return_error(req) {
-            let index = self
-                .counter
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Err(Box::new(MockHandlerError(index)))
-        } else {
-            self.delegate.finalize(req)
         }
     }
 }


### PR DESCRIPTION
Upon further reflection, I decided to revisit some of the changes from #24 and #21 . The main difference is that `Handler::sync` was changed back to return a `Result<SyncRequest, Error>`. The idea is basically that Handler shouldn't be _required_ to handle their own errors if they just want roperator to retry after a backoff period. This way, authors have the choice of whether they want to do their own error handling or let roperator do it for them.

In addition, the `roperator::handler::failable` module was added, which provides some other useful helpers for users who want to do some error handling in their Handlers. The `FailableHandler` trait was added to provide a somewhat more opinionated and simple trait for Handlers that want to opt in to error handling. The companion `DefaultFailableHandler` wraps `FalableHandler` impls and adapts them to the `Handler` trait.

So far, this seems like a better avenue for making error handling somewhat nicer, while still allowing users to easily implement it themselves. Nevertheless, I'd like to get some feedback on the API before cutting the 0.2 release.