### PR TITLE
CronJob is in batch/v1beta1 not batch/v1

### DIFF
--- a/src/k8s_types.rs
+++ b/src/k8s_types.rs
@@ -248,8 +248,10 @@ pub mod authorization_k8s_io {
 def_types! {
     batch => [
         v1 => [
-            CronJob ~ cronjobs,
             Job ~ jobs
+        ],
+        v1beta1 => [
+            CronJob ~ cronjobs
         ]
     ]
 }


### PR DESCRIPTION
Modifies `k8s_types.rs` to have `CronJob` under version `v1beta1` instead of `v1`.

Fixes #32 

> CronJob in k8s_types.rs is defined as under the v1 batch api, but it does not exist in this version. It exists under v1beta1 and is not in v1.
>
> This has the effect that if you specify .with_child(k8s_types::batch::v1::CronJob, ...) on your operator config then you get no events at all being processed, the operator appears to hang and do nothing. (which may perhaps be a separate bug?)

This operator config now processes events as expected:
```
    let operator_config = OperatorConfig::new(OPERATOR_NAME, PARENT_TYPE)
        .with_child(k8s_types::batch::v1beta1::CronJob, ChildConfig::replace());
```