### PR TITLE
Update project-setup.md

### DIFF
--- a/docs/guide/project-setup.md
+++ b/docs/guide/project-setup.md
@@ -57,7 +57,7 @@ env_logger = "0.7"
 
 # This is only needed if you intend to use the builtin testkit for testing your operator, which is probably a good idea
 [dev-dependencies]
-roperator = { version = "*", features = "testkit" }
+roperator = { version = "*", features = ["testkit"] }
 ```
 
 # Next


### PR DESCRIPTION
features without brackets causes the following issue:
```
error: failed to parse manifest at `/home/anton/code/core-dump-daemon/Cargo.toml`

Caused by:
  invalid type: string "testkit", expected a sequence for key `dev-dependencies.roperator.features`
```
This patch resolves it.