### PR TITLE
update setup-kind action to 0.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,10 @@ jobs:
         with:
           toolchain: 1.39.0
           override: true
-      - uses: engineerd/setup-kind@v0.1.0
+      - uses: engineerd/setup-kind@v0.5.0
       - uses: actions-rs/cargo@v1
       - name: RunTests
         run: |
-          export KUBECONFIG="$(kind get kubeconfig-path)"
           kubectl cluster-info
           kubectl apply -f tests/resources/
           cargo test --all-features


### PR DESCRIPTION
All earlier versions of setup-kind action have been deprecated, so this seems to be required in order for CI to start working again.