### PR TITLE
Update the dev-dependency of k8s-openapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ backoff = "0.1.6"
 anyhow = "1.0"
 
 [dev-dependencies]
-k8s-openapi = { version = "0.7.1", default-features = false, features = ["v1_15"] }
+k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
 env_logger = "0.7.1"
 chrono = "^0.4"
 protobuf = "=2.14.0"


### PR DESCRIPTION
Update to version 0.11 and bump the feature to v1_20