### PR TITLE
Change CAData::File variant to hold a PathBuf

### DIFF
--- a/docs/contributors-guide.md
+++ b/docs/contributors-guide.md
@@ -62,7 +62,7 @@ others who are interested in learning.
 
 The continuous integration checks are run on each PR. Here's how to run them locally:
 
-- `cargo test` : will run ONLY the unit tests (not the integration tests)
+- `cargo test --features test` : will run ONLY the unit tests (not the integration tests)
 - `cargo test --features 'testkit test'` will run all the tests, including integration tests. You'll need to have a few prerequisites:
     - Have a kubernetes cluster running. We use [kind](https://kind.sigs.k8s.io/) in the CI environment, but just about any local or remote cluster will work, as long as it's a test cluster. Don't run these tests on a production cluster, or any cluster that you feel attached to.
     - Ensure that you have a kubeconfig file that has the current context set to the cluster you want to use. You can set the `KUBECONFIG` environment variable if you don't want to use the default one in your home directory.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,10 @@ use crate::k8s_types::K8sType;
 
 use std::collections::HashMap;
 use std::io;
-use std::{path::Path, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 /// Default label that's added to all child resources, so that roperator can track the ownership of resources.
 /// The value is the `metadata.uid` of the parent.
@@ -173,7 +176,7 @@ impl OperatorConfig {
 #[derive(Debug, Clone, PartialEq)]
 pub enum CAData {
     /// The path to a file on disk that contains the CA certificate
-    File(String),
+    File(PathBuf),
     /// The base64 encoded certificate from a kubeconfig file. This value is already base64 encoded in the
     /// kubeconfig file, so you don't need to modify that value at all.
     Contents(String),
@@ -266,7 +269,7 @@ impl ClientConfig {
 
         let ca_file_path = Path::new(SERVICE_ACCOUNT_CA_PATH);
         let ca_data = if ca_file_path.exists() {
-            Some(CAData::File(SERVICE_ACCOUNT_CA_PATH.to_owned()))
+            Some(CAData::File(ca_file_path.to_owned()))
         } else {
             None
         };

--- a/src/config/kubeconfig.rs
+++ b/src/config/kubeconfig.rs
@@ -365,14 +365,11 @@ impl KubeConfig {
                     .certificate_authority
                     .clone()
                     .map(|ca_path| {
-                        // TODO: we'll need to make a breaking change to the CAData enum so that we can
-                        // always use Paths instead of strings for these
-                        let resolved_path =
-                            kube_config_dir.join(&ca_path).to_string_lossy().to_string();
+                        let resolved_path = kube_config_dir.join(&ca_path);
                         log::debug!(
                             "Resolved cluster certificate-authority path '{}' to '{}'",
                             ca_path.display(),
-                            resolved_path
+                            resolved_path.display()
                         );
                         CAData::File(resolved_path)
                     })
@@ -401,7 +398,7 @@ mod test {
         let user_agent = "my-user-agent";
         let loaded =
             load_kubeconfig(user_agent.to_string(), file).expect("failed to load kubeconfig");
-        let expected = CAData::File("src/config/test-data/./dummy-ca.crt".to_string());
+        let expected = CAData::File(PathBuf::from("src/config/test-data/./dummy-ca.crt"));
         assert_eq!(Some(expected), loaded.ca_data);
     }
 }

--- a/src/runner/client/mod.rs
+++ b/src/runner/client/mod.rs
@@ -125,7 +125,7 @@ impl Client {
                 }
             }
             Some(CAData::File(path)) => {
-                ssl.set_ca_file(path.as_str())?;
+                ssl.set_ca_file(&path)?;
             }
             None => {}
         }


### PR DESCRIPTION
Minor breaking change that switches the `CAData::File` variant to hold a
`PathBuf` instead of a `String`.

Fixes #11 